### PR TITLE
Run useToast effect once

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -174,7 +174,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure the `useToast` effect adds its listener only once and cleans up on unmount

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find @eslint/js and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf7b573e0833299fdf9f214767cd4