### PR TITLE
Handle zero direct distance in stop normalization

### DIFF
--- a/src/services/winnipegtransit.ts
+++ b/src/services/winnipegtransit.ts
@@ -47,6 +47,7 @@ export interface StopSchedule {
 function normalizeStop(raw: any): TransitStop {
   const geographic = raw.centre?.geographic || raw.geographic || { latitude: 0, longitude: 0 };
   const direct = raw.distances?.direct ?? undefined;
+  const walking = direct !== undefined ? Math.round(direct * 1.25) : undefined;
   return {
     key: Number(raw.key),
     name: raw.name,
@@ -57,7 +58,7 @@ function normalizeStop(raw: any): TransitStop {
       latitude: Number(geographic.latitude),
       longitude: Number(geographic.longitude),
     },
-    distances: direct !== undefined ? { direct, walking: direct ? Math.round(direct * 1.25) : undefined } : undefined,
+    distances: direct !== undefined ? { direct, walking } : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- Ensure stop normalization derives walking distance when direct distance is zero

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 17 problems (9 errors, 8 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68bdf7bd78f483329b028eded7b535b3