### PR TITLE
Expose map location callback to header compass

### DIFF
--- a/src/components/TransitMap.tsx
+++ b/src/components/TransitMap.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { MapPin, Navigation } from 'lucide-react';
 
 // Fix default marker icons
-// @ts-ignore
+// @ts-expect-error Leaflet's typings omit this method
 delete Icon.Default.prototype._getIconUrl;
 Icon.Default.mergeOptions({
   iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
@@ -34,9 +34,15 @@ interface TransitMapProps {
   onStopSelect?: (stop: TransitStop) => void;
   selectedStop?: TransitStop;
   className?: string;
+  onLocateUser?: (locateFn: () => void) => void;
 }
 
-export function TransitMap({ onStopSelect, selectedStop, className }: TransitMapProps) {
+export function TransitMap({
+  onStopSelect,
+  selectedStop,
+  className,
+  onLocateUser,
+}: TransitMapProps) {
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<L.Map | null>(null);
   const stopsLayerRef = useRef<L.LayerGroup | null>(null);
@@ -147,6 +153,12 @@ export function TransitMap({ onStopSelect, selectedStop, className }: TransitMap
       { enableHighAccuracy: true }
     );
   };
+
+  // Expose locate function to parent
+  useEffect(() => {
+    onLocateUser?.(locateUser);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onLocateUser]);
 
   // Center on selected stop
   useEffect(() => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,6 +10,7 @@ import { Bus, MapPin, Clock, Navigation, Search } from 'lucide-react';
 const Index = () => {
   const [selectedStop, setSelectedStop] = useState<TransitStop | null>(null);
   const [showSchedule, setShowSchedule] = useState(false);
+  const [locateUser, setLocateUser] = useState<() => void>(() => {});
 
   const handleStopSelect = (stop: TransitStop) => {
     setSelectedStop(stop);
@@ -36,10 +37,11 @@ const Index = () => {
                 <p className="text-primary-foreground/80 text-sm">Live bus schedules & navigation</p>
               </div>
             </div>
-            <Button 
-              variant="ghost" 
+            <Button
+              variant="ghost"
               size="sm"
               className="text-primary-foreground hover:bg-primary-foreground/20"
+              onClick={locateUser}
             >
               <Navigation className="w-4 h-4" />
             </Button>
@@ -115,10 +117,11 @@ const Index = () => {
           <div className="lg:col-span-2">
             <Card className="shadow-card h-full">
               <CardContent className="p-0 h-full">
-                <TransitMap 
+                <TransitMap
                   onStopSelect={handleStopSelect}
                   selectedStop={selectedStop || undefined}
                   className="h-full min-h-[400px] lg:min-h-full"
+                  onLocateUser={setLocateUser}
                 />
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- expose `locateUser` via TransitMap's `onLocateUser` prop
- trigger map centering from header compass button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npx eslint src/components/TransitMap.tsx src/pages/Index.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdfa3c9eec8332adcf4545da347803