### PR TITLE
feat: toast for geolocation errors

### DIFF
--- a/src/components/TransitMap.tsx
+++ b/src/components/TransitMap.tsx
@@ -4,6 +4,7 @@ import 'leaflet/dist/leaflet.css';
 import { TransitStop, winnipegTransitAPI } from '@/services/winnipegtransit';
 import { Button } from '@/components/ui/button';
 import { MapPin, Navigation } from 'lucide-react';
+import { toastError } from '@/hooks/use-toast';
 
 // Fix default marker icons
 // @ts-ignore
@@ -123,7 +124,10 @@ export function TransitMap({ onStopSelect, selectedStop, className }: TransitMap
   // Locate user and fetch nearby stops
   const locateUser = () => {
     if (!mapRef.current) return;
-    if (!navigator.geolocation) return;
+    if (!navigator.geolocation) {
+      toastError('Geolocation is not supported by your browser.');
+      return;
+    }
 
     navigator.geolocation.getCurrentPosition(
       async (pos) => {
@@ -142,7 +146,14 @@ export function TransitMap({ onStopSelect, selectedStop, className }: TransitMap
         await loadNearbyStops(latitude, longitude, 1000);
       },
       (err) => {
-        console.warn('Geolocation error', err);
+        if (err.code === err.PERMISSION_DENIED) {
+          toastError(
+            'Location access was denied. Please enable location permissions in your browser settings.',
+            'Permission Denied'
+          );
+        } else {
+          toastError(err.message || 'Failed to retrieve your location.', 'Geolocation Error');
+        }
       },
       { enableHighAccuracy: true }
     );

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -163,6 +163,14 @@ function toast({ ...props }: Toast) {
   };
 }
 
+function toastError(description: string, title = "Error") {
+  return toast({
+    title,
+    description,
+    variant: "destructive",
+  });
+}
+
 function useToast() {
   const [state, setState] = React.useState<State>(memoryState);
 
@@ -183,4 +191,4 @@ function useToast() {
   };
 }
 
-export { useToast, toast };
+export { useToast, toast, toastError };


### PR DESCRIPTION
## Summary
- show user-friendly toasts when geolocation fails
- add helper for standardized error toasts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Could not resolve @eslint/js / existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfa431f308332b8a7b0de029b66c0