### PR TITLE
feat: auto refresh stop schedule

### DIFF
--- a/src/components/StopSchedule.tsx
+++ b/src/components/StopSchedule.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { TransitStop, StopSchedule as StopScheduleType, winnipegTransitAPI } from '@/services/winnipegtransit';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -47,7 +47,7 @@ export function StopSchedule({ stop, onClose }: StopScheduleProps) {
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
 
-  const fetchSchedule = async () => {
+  const fetchSchedule = useCallback(async () => {
     setLoading(true);
     try {
       const scheduleData = await winnipegTransitAPI.getStopSchedule(stop.key);
@@ -61,11 +61,13 @@ export function StopSchedule({ stop, onClose }: StopScheduleProps) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [stop.key, toast]);
 
   useEffect(() => {
     fetchSchedule();
-  }, [stop.key]);
+    const intervalId = setInterval(fetchSchedule, 60000);
+    return () => clearInterval(intervalId);
+  }, [fetchSchedule]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- periodically refresh stop schedule every 60s
- clean up interval on unmount to prevent memory leaks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfa4b4f308332a4e06b6c92722b29