### PR TITLE
Expand stop schedule results

### DIFF
--- a/src/components/StopSchedule.tsx
+++ b/src/components/StopSchedule.tsx
@@ -85,8 +85,9 @@ export function StopSchedule({ stop, onClose }: StopScheduleProps) {
               <div key={i} className="space-y-2">
                 <Skeleton className="h-6 w-24" />
                 <div className="space-y-2">
-                  <Skeleton className="h-12 w-full" />
-                  <Skeleton className="h-12 w-full" />
+                  {Array.from({ length: 5 }).map((_, j) => (
+                    <Skeleton key={j} className="h-12 w-full" />
+                  ))}
                 </div>
               </div>
             ))}
@@ -203,7 +204,7 @@ export function StopSchedule({ stop, onClose }: StopScheduleProps) {
                   </div>
                   
                   <div className="space-y-1">
-                    {times.slice(0, 3).map((time: any, index: number) => {
+                    {times.slice(0, 10).map((time: any, index: number) => {
                       const isEstimated = !!time?.departure?.estimated;
                       const departureTime = time?.departure?.estimated || time?.departure?.scheduled;
                       

--- a/src/services/winnipegtransit.ts
+++ b/src/services/winnipegtransit.ts
@@ -81,8 +81,9 @@ export const winnipegTransitAPI = {
   // Get stop schedule
   async getStopSchedule(stopId: number): Promise<StopSchedule | null> {
     try {
+      const now = new Date().toISOString();
       const response = await fetch(
-        `${API_BASE_URL}/stops/${stopId}/schedule.json?max-results-per-route=3&api-key=${API_KEY}`
+        `${API_BASE_URL}/stops/${stopId}/schedule.json?max-results-per-route=10&start=${encodeURIComponent(now)}&api-key=${API_KEY}`
       );
       const data = await response.json();
       return data["stop-schedule"] || null;


### PR DESCRIPTION
## Summary
- Request more stop times from Winnipeg Transit, anchored to the current time
- Show up to ten departures per route and expand loading skeletons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: several lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdfdc9406483328f3874f58079e53f