### PR TITLE
feat: add theme toggle

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem {...props}>
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/ui/ModeToggle.tsx
+++ b/src/components/ui/ModeToggle.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function ModeToggle() {
+  const { setTheme } = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-primary-foreground hover:bg-primary-foreground/20"
+        >
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>Light</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>Dark</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>System</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { ThemeProvider } from "@/components/ThemeProvider";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>,
+);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,7 +6,8 @@ import { FavoriteStops } from '@/components/FavoriteStops';
 import { TransitStop } from '@/services/winnipegtransit';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Bus, MapPin, Clock, Navigation, Search } from 'lucide-react';
+import { Bus, Clock, Navigation, Search } from 'lucide-react';
+import { ModeToggle } from '@/components/ui/ModeToggle';
 
 const Index = () => {
   const [selectedStop, setSelectedStop] = useState<TransitStop | null>(null);
@@ -27,27 +28,30 @@ const Index = () => {
     <div className="min-h-screen bg-background">
       {/* Header */}
       <header className="bg-gradient-primary text-primary-foreground shadow-elegant sticky top-0 z-40">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-primary-foreground/20 rounded-lg backdrop-blur-sm">
-                <Bus className="w-6 h-6" />
+          <div className="container mx-auto px-4 py-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-primary-foreground/20 rounded-lg backdrop-blur-sm">
+                  <Bus className="w-6 h-6" />
+                </div>
+                <div>
+                  <h1 className="text-xl font-bold">Winnipeg Transit</h1>
+                  <p className="text-primary-foreground/80 text-sm">Live bus schedules & navigation</p>
+                </div>
               </div>
-              <div>
-                <h1 className="text-xl font-bold">Winnipeg Transit</h1>
-                <p className="text-primary-foreground/80 text-sm">Live bus schedules & navigation</p>
+              <div className="flex items-center gap-2">
+                <ModeToggle />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-primary-foreground hover:bg-primary-foreground/20"
+                  onClick={locateUser}
+                >
+                  <Navigation className="w-4 h-4" />
+                </Button>
               </div>
             </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-primary-foreground hover:bg-primary-foreground/20"
-              onClick={locateUser}
-            >
-              <Navigation className="w-4 h-4" />
-            </Button>
           </div>
-        </div>
       </header>
 
       <div className="container mx-auto p-4 max-w-7xl">


### PR DESCRIPTION
## Summary
- add theme provider and toggle components using next-themes
- wrap application with theme provider and integrate mode toggle in header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, prefer-const, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfcfea3008332af1b18cb5c4de7d3