### PR TITLE
Add trip planning and route visualization

### DIFF
--- a/src/components/TripPlanner.tsx
+++ b/src/components/TripPlanner.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { StopSearch } from './StopSearch';
+import { TransitStop, TripPlan, winnipegTransitAPI } from '@/services/winnipegtransit';
+import { Button } from '@/components/ui/button';
+
+interface TripPlannerProps {
+  onTripPlanned?: (trip: TripPlan | null) => void;
+}
+
+export function TripPlanner({ onTripPlanned }: TripPlannerProps) {
+  const [origin, setOrigin] = useState<TransitStop | null>(null);
+  const [destination, setDestination] = useState<TransitStop | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handlePlan = async () => {
+    if (!origin || !destination) return;
+    setLoading(true);
+    try {
+      const trip = await winnipegTransitAPI.planTrip(origin.key, destination.key);
+      onTripPlanned?.(trip);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <StopSearch onStopSelect={setOrigin} className="mb-2" />
+      <StopSearch onStopSelect={setDestination} className="mb-2" />
+      <Button onClick={handlePlan} disabled={!origin || !destination || loading} className="w-full">
+        {loading ? 'Planning...' : 'Plan Trip'}
+      </Button>
+    </div>
+  );
+}
+
+export default TripPlanner;

--- a/src/services/winnipegtransit.ts
+++ b/src/services/winnipegtransit.ts
@@ -43,6 +43,20 @@ export interface StopSchedule {
   stop: TransitStop;
   "route-schedules": RouteSchedule[];
 }
+
+export interface TripSegment {
+  type: string;
+  route?: { number: string; name: string };
+  from?: { name?: string };
+  to?: { name?: string };
+  times?: { start?: string; end?: string; departure?: string; arrival?: string };
+  shape?: { points?: string };
+  path?: [number, number][];
+}
+
+export interface TripPlan {
+  segments: TripSegment[];
+}
 // Helper to normalize API stop shape into our TransitStop
 function normalizeStop(raw: any): TransitStop {
   const geographic = raw.centre?.geographic || raw.geographic || { latitude: 0, longitude: 0 };
@@ -127,6 +141,37 @@ export const winnipegTransitAPI = {
     }
   },
 
+  // Plan trip between two stops
+  async planTrip(originId: number, destId: number): Promise<TripPlan | null> {
+    try {
+      const response = await fetch(`${API_BASE_URL}/trips.json?origin=${originId}&destination=${destId}&api-key=${API_KEY}`);
+      const data = await response.json();
+      const trip = data.trips?.[0];
+      if (!trip) return null;
+      const segments: TripSegment[] = (trip.segments || []).map((seg: any) => {
+        const pts: string | undefined = seg.shape?.points;
+        const path = pts
+          ? pts.trim().split(/\s+/).map((p: string) => {
+              const [lon, lat] = p.split(',').map(Number);
+              return [lat, lon] as [number, number];
+            })
+          : [];
+        return {
+          type: seg.type,
+          route: seg.route,
+          from: seg.from,
+          to: seg.to,
+          times: { start: seg.times?.start || seg.times?.departure, end: seg.times?.end || seg.times?.arrival },
+          shape: seg.shape,
+          path,
+        } as TripSegment;
+      });
+      return { segments };
+    } catch (error) {
+      console.error('Error planning trip:', error);
+      return null;
+    }
+  },
   // Get stop information by ID
   async getStop(stopId: number): Promise<TransitStop | null> {
     try {


### PR DESCRIPTION
## Summary
- add TripPlanner component to pick origin/destination and plan trips
- implement `planTrip` in Winnipeg Transit service
- render trip details and highlight route on map

## Testing
- `bun run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any)*
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdfd0682a88332b4645149a2a24e01