### PR TITLE
Add MapPin icon import to index page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,7 +8,7 @@ import { TripPlan } from '@/services/winnipegtransit';
 import { TransitStop } from '@/services/winnipegtransit';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Bus, Clock, Navigation, Search } from 'lucide-react';
+import { Bus, Clock, Navigation, Search, MapPin } from 'lucide-react';
 import { ModeToggle } from '@/components/ui/ModeToggle';
 
 const Index = () => {


### PR DESCRIPTION
## Summary
- import MapPin icon for trip planner card

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: lint errors in unrelated files)
- `npx eslint src/pages/Index.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be012e1158833296089cb32bff1049