### PR TITLE
feat: close schedule when switching stops

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -18,8 +18,14 @@ const Index = () => {
   const [trip, setTrip] = useState<TripPlan | null>(null);
 
   const handleStopSelect = (stop: TransitStop) => {
+    if (selectedStop && selectedStop.key !== stop.key) {
+      // Close the current schedule when a different stop is chosen
+      setShowSchedule(false);
+    } else {
+      // Toggle the schedule when selecting the same stop or on first selection
+      setShowSchedule((prev) => !prev);
+    }
     setSelectedStop(stop);
-    setShowSchedule(true);
   };
 
   const handleCloseSchedule = () => {


### PR DESCRIPTION
## Summary
- close existing schedule when selecting a different stop
- toggle schedule panel when re-selecting the same stop

## Testing
- `npm run lint` *(fails: Unexpected any, interface no members, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be0383d5548332934a64cccf9c83ed