### PR TITLE
Default route-schedules to array

### DIFF
--- a/src/components/StopSchedule.tsx
+++ b/src/components/StopSchedule.tsx
@@ -118,7 +118,6 @@ export function StopSchedule({ stop, onClose }: StopScheduleProps) {
   }
 
   const routeSchedules = Array.isArray(schedule["route-schedules"]) ? schedule["route-schedules"] : [];
-  const hasRouteSchedules = Array.isArray(schedule["route-schedules"]);
 
   return (
     <Card className="w-full max-w-md shadow-card bg-gradient-card">
@@ -168,13 +167,11 @@ export function StopSchedule({ stop, onClose }: StopScheduleProps) {
       </CardHeader>
 
       <CardContent className="pt-0">
-        {!hasRouteSchedules ? (
+        {routeSchedules.length === 0 ? (
           <p className="text-muted-foreground text-center py-4">
-            Schedule information unavailable
-          </p>
-        ) : routeSchedules.length === 0 ? (
-          <p className="text-muted-foreground text-center py-4">
-            No buses scheduled at this time
+            {Array.isArray(schedule["route-schedules"])
+              ? "No buses scheduled at this time"
+              : "Schedule information unavailable"}
           </p>
         ) : (
           <div className="space-y-4">


### PR DESCRIPTION
## Summary
- Guard against missing route schedules by defaulting to an empty array before evaluating

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-empty-object-type, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68be03a52a288332876d09aac8cc0e2f