### PR TITLE
feat: add winnipeg color palette

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -17,9 +17,9 @@ All colors MUST be HSL.
     --popover: 0 0% 100%;
     --popover-foreground: 210 11% 15%;
 
-    --primary: 210 100% 50%;
+    --primary: 218 100% 26%;
     --primary-foreground: 0 0% 100%;
-    --primary-glow: 210 100% 65%;
+    --primary-glow: 218 100% 36%;
 
     --secondary: 210 15% 92%;
     --secondary-foreground: 210 11% 15%;
@@ -27,16 +27,16 @@ All colors MUST be HSL.
     --muted: 210 15% 95%;
     --muted-foreground: 210 6% 46%;
 
-    --accent: 142 86% 28%;
+    --accent: 41 100% 55%;
     --accent-foreground: 0 0% 100%;
-    --accent-glow: 142 86% 40%;
+    --accent-glow: 41 100% 65%;
 
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
 
     --border: 210 20% 88%;
     --input: 210 20% 88%;
-    --ring: 210 100% 50%;
+    --ring: 218 100% 26%;
 
     --warning: 38 92% 50%;
     --warning-foreground: 0 0% 100%;
@@ -44,10 +44,10 @@ All colors MUST be HSL.
     --success: 142 86% 28%;
     --success-foreground: 0 0% 100%;
 
-    --transit-blue: 210 100% 50%;
-    --transit-blue-dark: 210 100% 40%;
-    --transit-green: 142 86% 28%;
-    --transit-orange: 25 95% 53%;
+    --transit-blue: 218 100% 26%;
+    --transit-blue-dark: 218 100% 16%;
+    --transit-green: 155 100% 30%;
+    --transit-orange: 23 100% 50%;
     --transit-purple: 262 100% 65%;
 
     --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-glow)));
@@ -82,9 +82,9 @@ All colors MUST be HSL.
     --popover: 210 11% 12%;
     --popover-foreground: 210 20% 98%;
 
-    --primary: 210 100% 65%;
+    --primary: 218 100% 41%;
     --primary-foreground: 210 11% 8%;
-    --primary-glow: 210 100% 75%;
+    --primary-glow: 218 100% 51%;
 
     --secondary: 210 11% 15%;
     --secondary-foreground: 210 20% 85%;
@@ -92,16 +92,16 @@ All colors MUST be HSL.
     --muted: 210 11% 15%;
     --muted-foreground: 210 6% 65%;
 
-    --accent: 142 86% 35%;
+    --accent: 41 100% 60%;
     --accent-foreground: 0 0% 100%;
-    --accent-glow: 142 86% 45%;
+    --accent-glow: 41 100% 70%;
 
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
 
     --border: 210 11% 20%;
     --input: 210 11% 20%;
-    --ring: 210 100% 65%;
+    --ring: 218 100% 41%;
 
     --warning: 38 92% 60%;
     --warning-foreground: 0 0% 100%;
@@ -109,10 +109,10 @@ All colors MUST be HSL.
     --success: 142 86% 35%;
     --success-foreground: 0 0% 100%;
 
-    --transit-blue: 210 100% 65%;
-    --transit-blue-dark: 210 100% 55%;
-    --transit-green: 142 86% 35%;
-    --transit-orange: 25 95% 63%;
+    --transit-blue: 218 100% 41%;
+    --transit-blue-dark: 218 100% 31%;
+    --transit-green: 155 100% 40%;
+    --transit-orange: 23 100% 60%;
     --transit-purple: 262 100% 75%;
 
     --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-glow)));


### PR DESCRIPTION
## Summary
- adopt Winnipeg Blue and Gold HSL values for primary and accent colors
- mirror updated palette in dark mode

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')


------
https://chatgpt.com/codex/tasks/task_e_68be03d0da1883328aba5222264fc1cd