### PR TITLE
style: enhance glass UI with larger radius

### DIFF
--- a/src/components/StopSchedule.tsx
+++ b/src/components/StopSchedule.tsx
@@ -121,7 +121,7 @@ export function StopSchedule({ stop, onClose }: StopScheduleProps) {
   const hasRouteSchedules = Array.isArray(schedule["route-schedules"]);
 
   return (
-    <Card className="w-full max-w-md shadow-card bg-gradient-card">
+    <Card className="w-full max-w-md shadow-card">
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between">
           <div>

--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -104,7 +104,7 @@ export function StopSearch({ onStopSelect, className }: StopSearchProps) {
             placeholder="Search stops by name or number..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="pl-10 pr-4 shadow-card"
+            className="pl-10 pr-4 shadow-card rounded-xl bg-background/50 backdrop-blur"
             onFocus={() => {
               if (results.length > 0) setShowResults(true);
             }}
@@ -116,7 +116,7 @@ export function StopSearch({ onStopSelect, className }: StopSearchProps) {
             placeholder="Filter by route number (optional)"
             value={route}
             onChange={(e) => setRoute(e.target.value)}
-            className="pl-10 pr-4 shadow-card"
+            className="pl-10 pr-4 shadow-card rounded-xl bg-background/50 backdrop-blur"
           />
         </div>
       </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,21 +5,22 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-medium ring-offset-background backdrop-blur transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        default: "bg-primary/80 text-primary-foreground hover:bg-primary/70",
+        destructive: "bg-destructive/80 text-destructive-foreground hover:bg-destructive/70",
+        outline:
+          "border border-input bg-background/50 hover:bg-accent/20 hover:text-accent-foreground",
+        secondary: "bg-secondary/80 text-secondary-foreground hover:bg-secondary/70",
+        ghost: "bg-background/20 hover:bg-accent/30 hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-9 rounded-xl px-3",
+        lg: "h-11 rounded-xl px-8",
         icon: "h-10 w-10",
       },
     },
@@ -39,7 +40,13 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
   },
 );
 Button.displayName = "Button";

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} {...props} />
+  <div ref={ref} className={cn("rounded-xl border bg-card/50 backdrop-blur text-card-foreground shadow-sm", className)} {...props} />
 ));
 Card.displayName = "Card";
 

--- a/src/index.css
+++ b/src/index.css
@@ -59,7 +59,7 @@ All colors MUST be HSL.
     --shadow-glow: 0 0 30px hsl(var(--primary-glow) / 0.3);
     --shadow-card: 0 2px 10px -2px hsl(var(--foreground) / 0.1);
 
-    --radius: 0.75rem;
+    --radius: 1rem;
     --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 
     --sidebar-background: 0 0% 98%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -90,9 +90,10 @@ export default {
         "smooth": "var(--transition-smooth)",
       },
       borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
+        xl: "var(--radius)",
+        lg: "calc(var(--radius) - 2px)",
+        md: "calc(var(--radius) - 4px)",
+        sm: "calc(var(--radius) - 6px)",
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary
- raise default radius to 1rem and extend rounded-xl support
- add glass-inspired Button and Card styles
- give StopSearch inputs and StopSchedule cards semi-transparent, blurred surfaces

## Testing
- ⚠️ `npm test` (script missing)
- ⚠️ `npm run lint` (ESLint missing type rules)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be03d1987483329114f07b633957b7