### PR TITLE
feat: plan trips and highlight routes

### DIFF
--- a/src/components/TransitMap.tsx
+++ b/src/components/TransitMap.tsx
@@ -36,7 +36,7 @@ interface TransitMapProps {
   selectedStop?: TransitStop;
   className?: string;
   onLocateUser?: (locateFn: () => void) => void;
-  tripPaths?: [number, number][][];
+  tripPaths?: { path: [number, number][]; color?: string }[];
 }
 
 export function TransitMap({
@@ -195,7 +195,8 @@ export function TransitMap({
     layer.clearLayers();
     if (!tripPaths || !tripPaths.length) return;
     tripPaths.forEach((p) => {
-      L.polyline(p, { color: "#0ea5e9", weight: 4 }).addTo(layer);
+      if (!p.path.length) return;
+      L.polyline(p.path, { color: p.color || "#0ea5e9", weight: 4 }).addTo(layer);
     });
     if (map) {
       const bounds = layer.getBounds();

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -102,10 +102,26 @@ const Index = () => {
                 <CardContent className="space-y-2 text-sm">
                   {trip.segments.map((seg, idx) => (
                     <div key={idx}>
-                      <p className="font-medium">{seg.route ? `Route ${seg.route.number} ${seg.route.name}` : seg.type}</p>
+                      <p className="font-medium">
+                        {seg.route ? `Route ${seg.route.number} ${seg.route.name}` : seg.type}
+                      </p>
+                      {seg.from?.name && seg.to?.name && (
+                        <p className="text-muted-foreground">
+                          {seg.from.name} → {seg.to.name}
+                        </p>
+                      )}
                       <p className="text-muted-foreground">
-                        {seg.times?.start && new Date(seg.times.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                        {seg.times?.end ? ` - ${new Date(seg.times.end).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}` : ''}
+                        {seg.times?.start &&
+                          new Date(seg.times.start).toLocaleTimeString([], {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          })}
+                        {seg.times?.end
+                          ? ` - ${new Date(seg.times.end).toLocaleTimeString([], {
+                              hour: '2-digit',
+                              minute: '2-digit',
+                            })}`
+                          : ''}
                       </p>
                     </div>
                   ))}
@@ -164,7 +180,7 @@ const Index = () => {
           <div className="lg:col-span-2">
             <Card className="shadow-card h-full">
               <CardContent className="p-0 h-full">
-                <TransitMap tripPaths={trip ? trip.segments.map(s => s.path || []) : undefined} 
+                <TransitMap tripPaths={trip ? trip.segments.map(s => ({ path: s.path || [], color: s.color })) : undefined}
                   onStopSelect={handleStopSelect}
                   selectedStop={selectedStop || undefined}
                   className="h-full min-h-[400px] lg:min-h-full"


### PR DESCRIPTION
## Summary
- implement trip planning API service returning leg paths and colors
- display trip legs with from-to info and times
- draw colored routes on the map

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/services/winnipegtransit.ts src/components/TransitMap.tsx src/pages/Index.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be03c078e4833281522d069e713f51