### PR TITLE
feat: tidy favorite stops card

### DIFF
--- a/src/components/FavoriteStops.tsx
+++ b/src/components/FavoriteStops.tsx
@@ -69,5 +69,3 @@ export function FavoriteStops({ onStopSelect, className }: FavoriteStopsProps) {
     </Card>
   );
 }
-
-export default FavoriteStops;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -92,7 +92,7 @@ const Index = () => {
             </Card>
 
             {/* Favorite Stops */}
-            <FavoriteStops onStopSelect={handleStopSelect} />
+            <FavoriteStops onStopSelect={handleStopSelect} className="shadow-card" />
 
             {trip && (
               <Card className="shadow-card">


### PR DESCRIPTION
## Summary
- clean up FavoriteStops component exports
- show FavoriteStops card with consistent styling on the index page

## Testing
- `npm run lint` *(fails: Unexpected any, no-empty-object-type, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68be03c2d5b48332af5ef9f238726100