### PR TITLE
feat: add bottom sheet for transit tools

### DIFF
--- a/src/components/TransitMap.tsx
+++ b/src/components/TransitMap.tsx
@@ -37,6 +37,7 @@ interface TransitMapProps {
   className?: string;
   onLocateUser?: (locateFn: () => void) => void;
   tripPaths?: [number, number][][];
+  onMapClick?: () => void;
 }
 
 export function TransitMap({
@@ -45,6 +46,7 @@ export function TransitMap({
   className,
   onLocateUser,
   tripPaths,
+  onMapClick,
 }: TransitMapProps) {
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<L.Map | null>(null);
@@ -181,6 +183,17 @@ export function TransitMap({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onLocateUser]);
 
+  // Handle map click events
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const handler = () => onMapClick?.();
+    map.on('click', handler);
+    return () => {
+      map.off('click', handler);
+    };
+  }, [onMapClick]);
+
   // Center on selected stop
   useEffect(() => {
     if (!selectedStop || !mapRef.current) return;
@@ -209,7 +222,7 @@ export function TransitMap({
 
   return (
     <div className={`relative ${className ?? ''}`}>
-      <div ref={mapContainerRef} className="w-full h-full min-h-[400px] rounded-lg" />
+      <div ref={mapContainerRef} className="w-full h-full" />
       <div className="absolute top-4 right-4 z-[1000]">
         <Button
           onClick={locateUser}

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { Sheet, SheetContent, SheetOverlay, SheetPortal } from "./sheet";
+
+interface BottomSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+export function BottomSheet({ open, onOpenChange, children }: BottomSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
+      <SheetPortal>
+        <SheetOverlay className="bg-transparent pointer-events-none" />
+        <SheetContent
+          side="bottom"
+          className="w-full max-h-[80vh] overflow-y-auto rounded-t-xl border-t bg-background/80 backdrop-blur-md"
+        >
+          {children}
+        </SheetContent>
+      </SheetPortal>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Summary
- implement bottom sheet component with Radix Sheet
- move planner, search, favorites, and schedule into bottom sheet overlay
- allow map tap to collapse sheet and stretch map behind overlay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 9 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68be07013a8083328cb05a1abc3ec3bb