### PR TITLE
feat: show trip legs with timeline component

### DIFF
--- a/src/components/RouteTimeline.tsx
+++ b/src/components/RouteTimeline.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { TripSegment } from '@/services/winnipegtransit';
+import { Bus, Clock, Footprints } from 'lucide-react';
+
+interface RouteTimelineProps {
+  segments: TripSegment[];
+}
+
+function formatTime(time?: string): string {
+  if (!time) return '';
+  try {
+    return new Date(time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return time;
+  }
+}
+
+function getLegType(seg: TripSegment): 'bus' | 'walk' | 'wait' {
+  if (seg.type === 'walk') return 'walk';
+  if (seg.type === 'ride') return 'bus';
+  return 'wait';
+}
+
+const iconMap = {
+  bus: <Bus className="w-4 h-4" />,
+  walk: <Footprints className="w-4 h-4" />,
+  wait: <Clock className="w-4 h-4" />,
+};
+
+const colorMap = {
+  bus: 'border-blue-500 bg-blue-50 text-blue-700',
+  walk: 'border-green-500 bg-green-50 text-green-700',
+  wait: 'border-yellow-500 bg-yellow-50 text-yellow-700',
+};
+
+export function RouteTimeline({ segments }: RouteTimelineProps) {
+  return (
+    <div className="space-y-2">
+      {segments.map((seg, idx) => {
+        const legType = getLegType(seg);
+        const icon = iconMap[legType];
+        const color = colorMap[legType];
+        const start = formatTime(seg.times?.start);
+        const end = formatTime(seg.times?.end);
+        const timeStr = start && end ? `${start} - ${end}` : start || end;
+        let label = '';
+        if (legType === 'bus') {
+          label = seg.route ? `Route ${seg.route.number} ${seg.route.name}` : 'Bus';
+        } else if (legType === 'walk') {
+          label = seg.to?.name ? `Walk to ${seg.to.name}` : 'Walk';
+        } else {
+          label = 'Wait';
+        }
+        return (
+          <div
+            key={idx}
+            className={`flex items-center gap-3 p-3 rounded border-l-4 ${color}`}
+          >
+            {icon}
+            <div className="flex-1 text-sm">
+              <p className="font-medium">{label}</p>
+              {timeStr && <p className="text-xs opacity-75">{timeStr}</p>}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default RouteTimeline;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import { StopSchedule } from '@/components/StopSchedule';
 import { StopSearch } from '@/components/StopSearch';
 import { FavoriteStops } from '@/components/FavoriteStops';
 import { TripPlanner } from '@/components/TripPlanner';
+import { RouteTimeline } from '@/components/RouteTimeline';
 import { TripPlan } from '@/services/winnipegtransit';
 import { TransitStop } from '@/services/winnipegtransit';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -105,16 +106,8 @@ const Index = () => {
                 <CardHeader className="pb-2">
                   <CardTitle className="text-lg">Trip Details</CardTitle>
                 </CardHeader>
-                <CardContent className="space-y-2 text-sm">
-                  {trip.segments.map((seg, idx) => (
-                    <div key={idx}>
-                      <p className="font-medium">{seg.route ? `Route ${seg.route.number} ${seg.route.name}` : seg.type}</p>
-                      <p className="text-muted-foreground">
-                        {seg.times?.start && new Date(seg.times.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                        {seg.times?.end ? ` - ${new Date(seg.times.end).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}` : ''}
-                      </p>
-                    </div>
-                  ))}
+                <CardContent>
+                  <RouteTimeline segments={trip.segments} />
                 </CardContent>
               </Card>
             )}


### PR DESCRIPTION
## Summary
- add RouteTimeline component to visualize bus, walk, and wait legs with icons and colors
- display planned trip segments using RouteTimeline on the index page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: repository has existing lint errors)
- `npx eslint src/components/RouteTimeline.tsx src/pages/Index.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be06fd8c208332958ab2a86b7f0a17