### PR TITLE
Refine card aesthetics and map presentation

### DIFF
--- a/src/components/StopSearch.tsx
+++ b/src/components/StopSearch.tsx
@@ -119,7 +119,7 @@ export function StopSearch({ onStopSelect, className }: StopSearchProps) {
             placeholder="Search stops by name or number..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="pl-10 pr-4 shadow-card rounded-xl bg-background/50 backdrop-blur"
+            className="pl-10 pr-4 shadow-card rounded-xl bg-background/60 backdrop-blur-md"
             onFocus={() => {
               if (results.length > 0) setShowResults(true);
             }}
@@ -131,7 +131,7 @@ export function StopSearch({ onStopSelect, className }: StopSearchProps) {
             placeholder="Filter by route number (optional)"
             value={route}
             onChange={(e) => setRoute(e.target.value)}
-            className="pl-10 pr-4 shadow-card rounded-xl bg-background/50 backdrop-blur"
+            className="pl-10 pr-4 shadow-card rounded-xl bg-background/60 backdrop-blur-md"
           />
         </div>
       </div>

--- a/src/components/TransitMap.tsx
+++ b/src/components/TransitMap.tsx
@@ -209,19 +209,19 @@ export function TransitMap({
 
   return (
     <div className={`relative ${className ?? ''}`}>
-      <div ref={mapContainerRef} className="w-full h-full min-h-[400px] rounded-lg" />
+      <div ref={mapContainerRef} className="w-full h-full min-h-[400px] rounded-xl overflow-hidden shadow-card" />
       <div className="absolute top-4 right-4 z-[1000]">
         <Button
           onClick={locateUser}
           size="sm"
           variant="secondary"
-          className="shadow-card bg-card/90 backdrop-blur-sm hover:bg-card"
+          className="shadow-card bg-card/80 backdrop-blur-md hover:bg-card"
         >
           <Navigation className="w-4 h-4" />
         </Button>
       </div>
       <div className="absolute bottom-4 left-4 z-[1000] pointer-events-none">
-        <div className="flex items-center gap-2 bg-background/80 backdrop-blur-sm px-3 py-2 rounded-md shadow-card">
+        <div className="flex items-center gap-2 bg-background/60 backdrop-blur-md px-3 py-2 rounded-md shadow-card">
           <MapPin className="w-4 h-4 text-primary" />
           <span className="text-xs text-muted-foreground">Tap a stop to view schedule</span>
         </div>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -3,7 +3,14 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("rounded-xl border bg-card/50 backdrop-blur text-card-foreground shadow-sm", className)} {...props} />
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card/80 backdrop-blur-md text-card-foreground shadow-card",
+      className,
+    )}
+    {...props}
+  />
 ));
 Card.displayName = "Card";
 

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -16,7 +16,7 @@ const HoverCardContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 w-64 rounded-md border bg-popover/80 backdrop-blur-md p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,7 @@ All colors MUST be HSL.
     --shadow-glow: 0 0 30px hsl(var(--primary-glow) / 0.3);
     --shadow-card: 0 2px 10px -2px hsl(var(--foreground) / 0.1);
 
+    /* Base border radius for UI elements */
     --radius: 1rem;
     --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -89,12 +89,13 @@ export default {
       transitionProperty: {
         "smooth": "var(--transition-smooth)",
       },
-      borderRadius: {
-        xl: "var(--radius)",
-        lg: "calc(var(--radius) - 2px)",
-        md: "calc(var(--radius) - 4px)",
-        sm: "calc(var(--radius) - 6px)",
-      },
+        borderRadius: {
+          DEFAULT: "var(--radius)",
+          xl: "var(--radius)",
+          lg: "calc(var(--radius) - 2px)",
+          md: "calc(var(--radius) - 4px)",
+          sm: "calc(var(--radius) - 6px)",
+        },
       keyframes: {
         "accordion-down": {
           from: {


### PR DESCRIPTION
## Summary
- elevate default border radius to 1rem and expose as default radius in Tailwind
- apply semi-transparent backgrounds with `backdrop-blur-md` across card components
- round map tiles with `rounded-xl` and add subtle shadows for depth

## Testing
- `npm run lint` (fails: Unexpected any, react-refresh warnings, require import)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be07041cd08332b0d85eea0293f310