### PR TITLE
feat: add favorite bar

### DIFF
--- a/src/components/FavoriteBar.tsx
+++ b/src/components/FavoriteBar.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { FavoriteStop, getFavorites } from '@/lib/favorites';
+import { Button } from '@/components/ui/button';
+import { TransitStop } from '@/services/winnipegtransit';
+import { cn } from '@/lib/utils';
+
+interface FavoriteBarProps {
+  onStopSelect: (stop: TransitStop) => void;
+  className?: string;
+}
+
+export function FavoriteBar({ onStopSelect, className }: FavoriteBarProps) {
+  const [favorites, setFavorites] = useState<FavoriteStop[]>([]);
+
+  useEffect(() => {
+    const load = () => setFavorites(getFavorites());
+    load();
+    window.addEventListener('storage', load);
+    return () => window.removeEventListener('storage', load);
+  }, []);
+
+  if (!favorites.length) return null;
+
+  const handleSelect = (fav: FavoriteStop) => {
+    const stop: TransitStop = {
+      ...fav,
+      geographic: { latitude: 0, longitude: 0 },
+    };
+    onStopSelect(stop);
+  };
+
+  return (
+    <div className={cn('border-b bg-background', className)}>
+      <div className="container mx-auto px-4">
+        <div className="flex gap-2 overflow-x-auto py-2">
+          {favorites.map((stop) => (
+            <Button
+              key={stop.key}
+              size="sm"
+              variant="secondary"
+              className="flex-shrink-0 whitespace-nowrap"
+              onClick={() => handleSelect(stop)}
+            >
+              {stop.name}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import { TransitMap } from '@/components/TransitMap';
 import { StopSchedule } from '@/components/StopSchedule';
 import { StopSearch } from '@/components/StopSearch';
 import { FavoriteStops } from '@/components/FavoriteStops';
+import { FavoriteBar } from '@/components/FavoriteBar';
 import { TripPlanner } from '@/components/TripPlanner';
 import { TripPlan } from '@/services/winnipegtransit';
 import { TransitStop } from '@/services/winnipegtransit';
@@ -66,6 +67,7 @@ const Index = () => {
             </div>
           </div>
       </header>
+      <FavoriteBar onStopSelect={handleStopSelect} />
 
       <div className="container mx-auto p-4 max-w-7xl">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 h-[calc(100vh-120px)]">


### PR DESCRIPTION
## Summary
- add FavoriteBar component that displays saved stops as horizontal buttons
- show FavoriteBar between the header and main map

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 16 problems)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be07031c908332b8444deab81d2d0c