### PR TITLE
Refactor TransitMap layout

### DIFF
--- a/src/components/TransitMap.tsx
+++ b/src/components/TransitMap.tsx
@@ -222,7 +222,7 @@ export function TransitMap({
 
   return (
     <div className={`relative ${className ?? ''}`}>
-      <div ref={mapContainerRef} className="w-full h-full" />
+      <div ref={mapContainerRef} className="absolute inset-0" />
       <div className="absolute top-4 right-4 z-[1000]">
         <Button
           onClick={locateUser}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -78,7 +78,7 @@ const Index = () => {
           tripPaths={trip ? trip.segments.map((s) => s.path || []) : undefined}
           onStopSelect={handleStopSelect}
           selectedStop={selectedStop || undefined}
-          className="absolute inset-0"
+          className="h-full w-full"
           onLocateUser={setLocateUser}
           onMapClick={handleMapClick}
         />


### PR DESCRIPTION
## Summary
- move absolute positioning into `TransitMap` so map fills parent
- keep `TransitMap` in normal flow on index page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be09d425ec8332a8350527330b40c6